### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ These deployment scripts are provided 'as is', without warranty. See [Copyright 
 
 ## Prerequisites
 
+* download `gcloud` CLI
+* download `terraform` CLI
+* ensure user's IAM policies have `secretmanager.versions.access` enabled
+* perform `gcloud auth login` before performing terraform commands
 * A Virtual Private Cloud (VPC) - Required in the '**`vpc_name`**' input variable.
 * A network subnet attached to the VPC with [Private Google Access](https://cloud.google.com/vpc/docs/private-google-access) enabled (Resources will be created in the subnet's region) -  Required in the '**`subnet_name`**' input variable.
 * Datadog API Key - Required in the '**`datadog_api_key`**' input variable

--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ These deployment scripts are provided 'as is', without warranty. See [Copyright 
 
 ## Prerequisites
 
-* download `gcloud` CLI
-* download `terraform` CLI
-* ensure user's IAM policies have `secretmanager.versions.access` enabled
-* perform `gcloud auth login` before performing terraform commands
+* Download `gcloud` CLI.
+* Download `terraform` CLI.
+* Ensure user's IAM policies have `secretmanager.versions.access` enabled.
+* Perform `gcloud auth login` before performing terraform commands.
 * A Virtual Private Cloud (VPC) - Required in the '**`vpc_name`**' input variable.
 * A network subnet attached to the VPC with [Private Google Access](https://cloud.google.com/vpc/docs/private-google-access) enabled (Resources will be created in the subnet's region) -  Required in the '**`subnet_name`**' input variable.
 * Datadog API Key - Required in the '**`datadog_api_key`**' input variable


### PR DESCRIPTION
Update prerequisites to reflect minimal permissions and tooling needed to run terraform apply.

* Was not clear the user had to have `secretmanager.versions.access` on their IAM policies
* Was not clear the user had to auth to gcloud to use terraform
* Was not clear the user needs both gcloud and terraform CLI.