### PR TITLE
Update GCP version constraint to include current version

### DIFF
--- a/gcp-datadog-module/providers.tf
+++ b/gcp-datadog-module/providers.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.0.0, < 6"
+      version = ">= 5.0.0, < 7"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.0.0, < 6"
+      version = ">= 5.0.0, < 7"
     }
   }
 }


### PR DESCRIPTION
The APIs used seem compatible with the current version (terraform plan ran fine for me), so bumping these version constraints.