### PR TITLE
Disable bucket soft delete to reduce costs

### DIFF
--- a/gcp-datadog-module/log-sink.tf
+++ b/gcp-datadog-module/log-sink.tf
@@ -56,4 +56,7 @@ resource "google_storage_bucket" "temp_files_bucket" {
   storage_class               = "STANDARD"
   public_access_prevention    = "enforced"
   labels                      = { storage-bucket-label = "datadog_terraform" }
+  soft_delete_policy {
+    retention_duration_seconds = 0
+  }
 }


### PR DESCRIPTION
Google Cloud Storage [now supports soft delete](https://cloud.google.com/resources/storage/soft-delete-announce) and enables it by default on buckets. I suggest disabling it by default for the bucket storing dataflow temp files to reduce costs.